### PR TITLE
Add per-process HTTP metrics

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -147,7 +147,7 @@ metrics:
   # Update interval settings in seconds.
   interval:
     # Update interval for general system stats reporting.
-    systemUpdate: 60
+    systemUpdate: 10
   # Settings for the StatsD backend (see config/statsd.js).
   # Only the host and prefix settings are special, as they are used for the
   # client-only configuration.
@@ -161,7 +161,7 @@ metrics:
 
     # The following settings only have effect if spawning is enabled.
 
-    flushInterval: 60000
+    flushInterval: 10000
     # Native backends include:
     # + ./backends/graphite
     # + ./backends/console

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -4,11 +4,25 @@ var StatsdClient = require('statsd-client');
 var CONFIG = require('config');
 var os = require('os');
 var cluster = require('cluster');
+var http = require('http');
 
+var forEach = require('./util').forEach;
 var log = require('./log');
 
 // Timer metric timeout in ms.
 var TIMEOUT = exports.TIMEOUT = 60000;
+// Default sytem update interval in ms.
+var UPDATE_INTERVAL = 10000;
+
+// Return the current time.
+function now() {
+  return new Date();
+}
+
+// Return time difference in ms.
+function duration(startTime) {
+  return now().getTime() - startTime.getTime();
+}
 
 // Timer used to report time metrics.
 var Timer = function(metrics, key, timeout) {
@@ -25,7 +39,7 @@ Timer.prototype.start = function() {
   var key = this.key;
 
   this.clear();
-  this.startTime = metrics.now();
+  this.startTime = now();
 
   this._timeout = setTimeout(function() {
     metrics.count(key + '.overdue');
@@ -43,7 +57,7 @@ Timer.prototype.stop = function() {
   }
 
   this.metrics.timing(this.key, this.startTime);
-  this.duration = this.metrics.now().getTime() - this.startTime.getTime();
+  this.duration = duration(this.startTime);
   this.clear();
 
   return this.duration;
@@ -117,6 +131,8 @@ Session.prototype.streamTimer = function(stream, key, timeout) {
 var Metrics = function(options) {
   this.clients = [];
   this.systemSession = this.session('system');
+  this.updateInterval = options.metrics.interval.systemUpdate * 1000 ||
+                        UPDATE_INTERVAL;
 
   if (!options.metrics.enabled) {
     return;
@@ -131,11 +147,8 @@ var Metrics = function(options) {
 
   this.clients.push(statsdClient);
 
-  // Activate general system metrics on the master process.
-  if (cluster.isMaster) {
-    setInterval(this.update.bind(this),
-                options.metrics.interval.systemUpdate * 1000);
-  }
+  // Activate general system metrics.
+  setInterval(this.update.bind(this), this.updateInterval);
 };
 
 // Return a new metrics session for given prefix name.
@@ -157,43 +170,55 @@ Metrics.prototype.use = function(client) {
   }
 };
 
-// Return the current time.
-Metrics.prototype.now = function() {
-  return new Date();
-};
-
 // Update the system metrics.
 Metrics.prototype.update = function() {
-  var numCpus = os.cpus().length;
+  var metrics = this;
 
-  this.systemSession.gauge('cpu.num', numCpus);
-  this.systemSession.gauge('cpu.load.avg', os.loadavg()[0]);
-  this.systemSession.gauge('memory.total', os.totalmem());
-  this.systemSession.gauge('memory.free', os.freemem());
+  if (cluster.isMaster) {
+    var numCpus = os.cpus().length;
 
-  // Collect average CPU usage stats.
-  var cpuStats = { speed: 0, user: 0, nice: 0, sys: 0, idle: 0, irq: 0 };
-  os.cpus().forEach(function(cpu) {
-    cpuStats.speed += cpu.speed;
-    cpuStats.user += cpu.times.user;
-    cpuStats.nice += cpu.times.nice;
-    cpuStats.sys += cpu.times.sys;
-    cpuStats.idle += cpu.times.idle;
-    cpuStats.irq += cpu.times.irq;
-  });
+    this.systemSession.gauge('cpu.num', numCpus);
+    this.systemSession.gauge('cpu.load.avg', os.loadavg()[0]);
+    this.systemSession.gauge('memory.total', os.totalmem());
+    this.systemSession.gauge('memory.free', os.freemem());
 
-  for (var s in cpuStats) {
-    if (cpuStats.hasOwnProperty(s)) {
-      cpuStats[s] /= numCpus;
-      this.systemSession.gauge('cpu.' + s + '.avg', cpuStats[s]);
-    }
+    // Collect average CPU usage stats.
+    var cpuStats = { speed: 0, user: 0, nice: 0, sys: 0, idle: 0, irq: 0 };
+    os.cpus().forEach(function(cpu) {
+      cpuStats.speed += cpu.speed;
+      cpuStats.user += cpu.times.user;
+      cpuStats.nice += cpu.times.nice;
+      cpuStats.sys += cpu.times.sys;
+      cpuStats.idle += cpu.times.idle;
+      cpuStats.irq += cpu.times.irq;
+    });
+
+    forEach(cpuStats, function(stat, s) {
+      stat /= numCpus;
+      metrics.systemSession.gauge('cpu.' + s + '.avg', stat);
+    });
   }
+
+  function lengthSum(obj) {
+    var s = 0;
+    forEach(obj, function(e) {
+      s += e.length;
+    });
+    return s;
+  }
+
+  // Report per-process HTTP stats.
+  this.systemSession.count('sockets', lengthSum(http.globalAgent.sockets));
+  this.systemSession.count('requests', lengthSum(http.globalAgent.requests));
+
   log.debug('reporting system metrics');
 };
 
 // Change the count value for given key by the given delta.
 Metrics.prototype.count = function(key, delta) {
-  delta = delta || 1;
+  if (delta === undefined) {
+    delta = 1;
+  }
 
   this.clients.forEach(function(client) {
     if (client.counter) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,3 +19,11 @@ exports.kbToByte = function(kb) {
 exports.mbToByte = function(mb) {
   return mb * 1048576;
 };
+
+exports.forEach = function(obj, callback) {
+  for (var id in obj) {
+    if (obj.hasOwnProperty(id)) {
+      callback(obj[id], id);
+    }
+  }
+};


### PR DESCRIPTION
I think this is the most sane way to provide per-process metrics. We won't catch all the networking spikes with it, but would detect the overall socket usage and eventual hangs.

It also gives us a variable to tweak, to get more fine grained results. We should be able to reduce the update interval to 1-3s (currently at 10s) without introducing noticeable overhead.
