### PR TITLE
Fix StatsD client prefix

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -217,7 +217,7 @@ var Metrics = function(options) {
     var statsdClient = new StatsdClient({
       host: options.metrics.statsd.host,
       port: options.metrics.statsd.port,
-      prefix: options.metrics.statsd.prefix
+      prefix: options.metrics.statsd.prefix + '.'
     });
 
     this.clients.push(statsdClient);


### PR DESCRIPTION
The new client does not append the `.` automatically.
