### PR TITLE
Do not modify DOM for unproxied elements

### DIFF
--- a/lib/plugins/dom/gif2video.js
+++ b/lib/plugins/dom/gif2video.js
@@ -70,21 +70,24 @@ exports.handleDOMResponse = function(request, source, $, callback) {
     var src = $(el).attr('src');
     if (src && src.match(/\.gif$/i)) {
       var gifSrc = url.resolve(request.url, src);
-      var webmSrc = gifSrc.replace(/\.gif$/i, '.webm');
 
-      pendingIntercepts[webmSrc] = gifSrc;
-      var newEl = $(util.format('<video autoplay loop src="%s"></video>',
-        webmSrc));
+      if (url.parse(gifSrc).protocol === 'http:') {
+        var webmSrc = gifSrc.replace(/\.gif$/i, '.webm');
 
-      // Copy some attribute values to the new video element
-      ['id', 'class', 'style'].forEach(function(attr) {
-        var val = $(el).attr(attr);
-        if (val) {
-          newEl.attr(attr, val);
-        }
-      });
+        pendingIntercepts[webmSrc] = gifSrc;
+        var newEl = $(util.format('<video autoplay loop src="%s"></video>',
+                                  webmSrc));
 
-      $(el).replaceWith(newEl);
+        // Copy some attribute values to the new video element
+        ['id', 'class', 'style'].forEach(function(attr) {
+          var val = $(el).attr(attr);
+          if (val) {
+            newEl.attr(attr, val);
+          }
+        });
+
+        $(el).replaceWith(newEl);
+      }
     }
   });
 


### PR DESCRIPTION
We modify the request URL for GIFs even for HTTPS resources, which we don't handle and therefore never load, since they don't exist at the original host.

Test page: http://slides.com/sylvaincleymans/janus#/18
