### PR TITLE
README: added details to generate self-signed cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ To view and process the full metrics, you need a receiver compatible to StatsD
 metrics. To establish a connection, simply set the `metrics.statsd` settings
 accordingly in `config/default.yml` or your local overriding config files.
 
+### Self-Signed Certificate
+You will also need to use your own certificate for your server FQDN. You can
+generate a new key and a new certificate simply by launching this command from
+`node-janus` root directory:
+
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout keys/key.pem -out keys/crt.pem
+
+Be careful to correctly set the `Common Name` with your server FQDN, e.g. for
+`example.com`:
+
+    Common Name (e.g. server FQDN or YOUR name) []:example.com
+
+Because a self-signed certificate is not delivered by a trusted CA, you will
+have to manually add it to your browser. Please have a look to the [Firefox](#firefox)
+section for more details.
+
 ## Development
 ### Additional Requirements
 * [spdylay](https://github.com/tatsuhiro-t/spdylay)


### PR DESCRIPTION
Hello,

Thank you for developing this nice privacy and compression proxy :-)

I'm just proposing here to improve the README file and add details about how to generate a self-signed certificate. Every time I have to generate a new key and certificate, I have to find the correct options :-)

I also added a link to the next section: how to validate the self-signed certificate on Firefox? I didn't see these details maybe because I already used Janus Configurator Proxy add-on before and I thought that there was something wrong with my certificate... It was my fault but I hope these new details will help other absent-minded people :-)

Last details: I added the minimal version for Firefox.

If you want, I just created a Dockerfile and a docker repository to quickly build `node-janus` on a container:
- https://github.com/matttbe/docker-janus-node
- https://registry.hub.docker.com/u/matttbe/docker-janus-node/

Have a nice day,

Matt
