### PR TITLE
README: Firefox: minimal version = 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ The only command-line arguments supported are `-h` for help and `-v` for
 showing the version.
 
 ### Firefox
-You need [Firefox Nightly](http://nightly.mozilla.org) for SPDY proxy support.
+#### Minimal Version
+You need at least Firefox 33 ([Firefox Beta](http://beta.mozilla.org)) for SPDY
+proxy support.
+
+#### Self-Signed Certificates
 When using self-signed certificates, you need to add it to Firefox first. To do
 this, use Firefox to call the proxy via its host-port combination.
 


### PR DESCRIPTION
Hello,

This commit adds the minimal version (33) of Firefox which contains the support of a SPDY Proxy.
And this version (33) is the current Beta and not the current Nightly version.

Have a nice day,

Matt

PS: sorry for having created one pull request with two commits about two different things.
