### PR TITLE
Selective metrics reporting

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -182,6 +182,10 @@ video:
 # Metrics reporting settings.
 metrics:
   enabled: true
+  # Metrics selection allows to restrict metrics reports to a whitelisted set.
+  selection:
+    enabled: false
+    set: ['proxy.request', 'proxy.response']
   # All update interval settings are in seconds.
   # General system metrics settings.
   system:

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -209,6 +209,7 @@ Session.prototype.streamTimer = function(stream, key, timeout) {
 // Metrics engine, used to track times and counters.
 var Metrics = function(options) {
   var metrics = this;
+  metrics.options = options.metrics;
   metrics.clients = [];
   metrics.systemSession = metrics.session('system');
 
@@ -356,8 +357,27 @@ Metrics.prototype.update = function() {
   log.debug('reporting system metrics');
 };
 
+// Check whether we should log the specific metric.
+Metrics.prototype.shouldLog = function(key) {
+  if (!this.options.selection.enabled) {
+    return true;
+  }
+
+  for (var i = 0; i < this.options.selection.set.length; ++i) {
+    if (this.options.selection.set[i] === key) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 // Change the count value for given key by the given delta.
 Metrics.prototype.count = function(key, delta) {
+  if (!this.shouldLog(key)) {
+    return;
+  }
+
   if (delta === undefined) {
     delta = 1;
   }
@@ -385,6 +405,10 @@ Metrics.prototype.count = function(key, delta) {
 
 // Update the 'gauge' value for given key.
 Metrics.prototype.gauge = function(key, value) {
+  if (!this.shouldLog(key)) {
+    return;
+  }
+
   this.clients.forEach(function(client) {
     if (client.gauge) {
       client.gauge(key, value);
@@ -393,6 +417,10 @@ Metrics.prototype.gauge = function(key, value) {
 };
 
 Metrics.prototype.set = function(key, value) {
+  if (!this.shouldLog(key)) {
+    return;
+  }
+
   this.clients.forEach(function(client) {
     if (client.set) {
       client.set(key, value);
@@ -402,6 +430,10 @@ Metrics.prototype.set = function(key, value) {
 
 // Add a timing entry for given key with given duration.
 Metrics.prototype.timing = function(key, duration) {
+  if (!this.shouldLog(key)) {
+    return;
+  }
+
   this.clients.forEach(function(client) {
     if (client.timing) {
       client.timing(key, duration);

--- a/lib/plugins/imgcompression.js
+++ b/lib/plugins/imgcompression.js
@@ -70,7 +70,6 @@ exports.handleResponse = function(request, source, dest) {
     });
   } else {
     if (isSupportedImageFormat(imgType)) {
-      console.log(imgType);
       metrics.count('type.' + imgType + '.miss');
     }
 


### PR DESCRIPTION
We're logging a ton of metrics, which is good, but could cause side effects on the operations. With selective metrics reporting we can reduce the amount of metrics while maintaining some overview over the operations for testing.
